### PR TITLE
deps: update goffi v0.3.8 → v0.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-02-18
+
+### Changed
+
+- **goffi:** v0.3.8 → v0.3.9 (ARM64 callback trampoline fix, symbol rename to avoid linker collision)
+
+---
+
 ## [0.3.0] - 2026-02-09
 
 ### Added

--- a/UPSTREAM.md
+++ b/UPSTREAM.md
@@ -10,13 +10,14 @@ This document tracks upstream dependencies, pinned versions, and compatibility f
 |------------|---------|--------|------|
 | **wgpu-native** | [v27.0.4.0](https://github.com/gfx-rs/wgpu-native/releases/tag/v27.0.4.0) | [`768f15f`](https://github.com/gfx-rs/wgpu-native/commit/768f15f6ace8e4ec8e8720d5732b29e0b34250a8) | 2025-12-23 |
 | **webgpu.h** | wgpu-native bundled | same as above | — |
-| **goffi** | [v0.3.8](https://github.com/go-webgpu/goffi/releases/tag/v0.3.8) | [`7e28f50`](https://github.com/go-webgpu/goffi/commit/7e28f50ab6c33c660b840d75bb55de39fdc35649) | 2026-01-29 |
+| **goffi** | [v0.3.9](https://github.com/go-webgpu/goffi/releases/tag/v0.3.9) | [`aa78271`](https://github.com/go-webgpu/goffi/commit/aa782710c349c09cebe2e5b9f76df859512884ef) | 2026-02-18 |
 | **gputypes** | [v0.2.0](https://github.com/gogpu/gputypes/releases/tag/v0.2.0) | [`146b8b2`](https://github.com/gogpu/gputypes/commit/146b8b253ad16fe23db83cc593601081d009e3a6) | 2026-01-29 |
 
 ## Compatibility Matrix
 
 | go-webgpu | wgpu-native | goffi | gputypes | Go |
 |-----------|-------------|-------|----------|----|
+| v0.3.1 | v27.0.4.0 | v0.3.9 | v0.2.0 | 1.25+ |
 | v0.3.0 | v27.0.4.0 | v0.3.8 | v0.2.0 | 1.25+ |
 | v0.2.1 | v27.0.4.0 | v0.3.8 | v0.2.0 | 1.25+ |
 | v0.2.0 | v27.0.4.0 | v0.3.7 | v0.2.0 | 1.25+ |
@@ -104,4 +105,4 @@ Enum values in gputypes follow the webgpu.h specification. When gputypes updates
 
 ---
 
-*Last updated: 2026-02-09 (v0.3.0)*
+*Last updated: 2026-02-18 (v0.3.1)*

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/go-webgpu/webgpu
 
 go 1.25
 
-require github.com/go-webgpu/goffi v0.3.8
+require github.com/go-webgpu/goffi v0.3.9
 
 require golang.org/x/sys v0.40.0
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/go-webgpu/goffi v0.3.8 h1:Kzw7oP1XEjkv+6QvOIWwuNMfW3iOTPq0hQjr14YwVBM=
-github.com/go-webgpu/goffi v0.3.8/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
+github.com/go-webgpu/goffi v0.3.9 h1:dD1F7GZQV54ET6Fdcb+4776W1/OfbSb9DOJADVZEQLc=
+github.com/go-webgpu/goffi v0.3.9/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/gogpu/gputypes v0.2.0 h1:Quv3ekiU12zK4ZhBZsSZmalHYc+zj2gr9ZWRyzKgkKk=
 github.com/gogpu/gputypes v0.2.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 golang.org/x/sys v0.40.0 h1:DBZZqJ2Rkml6QMQsZywtnjnnGvHza6BTfYFWY9kjEWQ=


### PR DESCRIPTION
## Summary

- Update goffi v0.3.8 → v0.3.9
- ARM64 callback trampoline rewrite — fixes LR corruption for callbacks at index > 0
- Symbol rename to avoid linker collision with purego
- Update `UPSTREAM.md` with new pinned version and commit SHA
- Update `CHANGELOG.md` with v0.3.1 entry

## Test plan

- [x] `go test ./wgpu/...` passes locally
- [x] `go mod tidy` clean
