### PR TITLE
deps: update goffi v0.4.0 → v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-03-02
+
+### Changed
+
+- Update goffi v0.4.0 → v0.4.1 — ABI compliance hotfix (float32 encoding, stack spill for 7+ args, struct return, runtime.KeepAlive)
+
+---
+
 ## [0.4.0] - 2026-02-27
 
 ### Added

--- a/UPSTREAM.md
+++ b/UPSTREAM.md
@@ -10,13 +10,15 @@ This document tracks upstream dependencies, pinned versions, and compatibility f
 |------------|---------|--------|------|
 | **wgpu-native** | [v27.0.4.0](https://github.com/gfx-rs/wgpu-native/releases/tag/v27.0.4.0) | [`768f15f`](https://github.com/gfx-rs/wgpu-native/commit/768f15f6ace8e4ec8e8720d5732b29e0b34250a8) | 2025-12-23 |
 | **webgpu.h** | wgpu-native bundled | same as above | — |
-| **goffi** | [v0.4.0](https://github.com/go-webgpu/goffi/releases/tag/v0.4.0) | [`6fe9a0b`](https://github.com/go-webgpu/goffi/commit/6fe9a0b12ec1b89ae6ae37a746c48445f6125c9f) | 2026-02-27 |
+| **goffi** | [v0.4.1](https://github.com/go-webgpu/goffi/releases/tag/v0.4.1) | [`7e87b11`](https://github.com/go-webgpu/goffi/commit/7e87b11) | 2026-03-02 |
 | **gputypes** | [v0.2.0](https://github.com/gogpu/gputypes/releases/tag/v0.2.0) | [`146b8b2`](https://github.com/gogpu/gputypes/commit/146b8b253ad16fe23db83cc593601081d009e3a6) | 2026-01-29 |
 
 ## Compatibility Matrix
 
 | go-webgpu | wgpu-native | goffi | gputypes | Go |
 |-----------|-------------|-------|----------|----|
+| v0.4.1 | v27.0.4.0 | v0.4.1 | v0.2.0 | 1.25+ |
+| v0.4.0 | v27.0.4.0 | v0.4.0 | v0.2.0 | 1.25+ |
 | v0.3.2 | v27.0.4.0 | v0.4.0 | v0.2.0 | 1.25+ |
 | v0.3.1 | v27.0.4.0 | v0.3.9 | v0.2.0 | 1.25+ |
 | v0.3.0 | v27.0.4.0 | v0.3.8 | v0.2.0 | 1.25+ |
@@ -106,4 +108,4 @@ Enum values in gputypes follow the webgpu.h specification. When gputypes updates
 
 ---
 
-*Last updated: 2026-02-27 (v0.3.2)*
+*Last updated: 2026-03-02 (v0.4.1)*

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/go-webgpu/webgpu
 
 go 1.25
 
-require github.com/go-webgpu/goffi v0.4.0
+require github.com/go-webgpu/goffi v0.4.1
 
 require golang.org/x/sys v0.40.0
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/go-webgpu/goffi v0.4.0 h1:KX/p9hd2n5uqTfDrsiQOU9dOPIsVl/RViY2foFq4r34=
-github.com/go-webgpu/goffi v0.4.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
+github.com/go-webgpu/goffi v0.4.1 h1:2hQH5XXloxTyTtIleYv+Rajlwzp6UOETURhSZ5+zJxU=
+github.com/go-webgpu/goffi v0.4.1/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/gogpu/gputypes v0.2.0 h1:Quv3ekiU12zK4ZhBZsSZmalHYc+zj2gr9ZWRyzKgkKk=
 github.com/gogpu/gputypes v0.2.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 golang.org/x/sys v0.40.0 h1:DBZZqJ2Rkml6QMQsZywtnjnnGvHza6BTfYFWY9kjEWQ=


### PR DESCRIPTION
## Summary

- Update goffi v0.4.0 → v0.4.1 (ABI compliance hotfix)
- Update `UPSTREAM.md` pinned version and compatibility matrix
- Update `CHANGELOG.md` with v0.4.1 entry

### goffi v0.4.1 highlights

- Float32 argument encoding bug fix
- AMD64/ARM64 stack spill for 7+/9+ arguments
- Struct return fixes (9-16B register pair, sret hidden pointer)
- `runtime.KeepAlive` after FFI calls to prevent GC of argument pointers
- Overflow detection (`ErrTooManyArguments`)
