### PR TITLE
ci: upgrade Codecov to v5 with OIDC tokenless upload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,9 @@ jobs:
   unit-tests:
     name: Unit Tests - ${{ matrix.os }} - Go ${{ matrix.go-version }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      id-token: write  # Required for Codecov OIDC tokenless upload
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]  # macos-latest = ARM64 (Apple Silicon)
@@ -111,12 +114,15 @@ jobs:
 
     - name: Upload coverage to Codecov
       if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.25'
-      uses: codecov/codecov-action@v4
-      continue-on-error: true
+      uses: codecov/codecov-action@v5
       with:
-        file: ./coverage.txt
+        use_oidc: true
+        slug: go-webgpu/webgpu
+        files: ./coverage.txt
         flags: unittests
-        name: codecov-unit
+        name: codecov-webgpu
+        fail_ci_if_error: false
+        verbose: true
 
   lint:
     name: Lint

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,25 @@
+codecov:
+  branch: main
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 5%
+
+ignore:
+  - "examples/**/*"
+  - "cmd/**/*"
+
+parsers:
+  go:
+    partials_as_hits: false
+
+comment:
+  layout: "header, diff, flags, components"
+  behavior: default
+  require_changes: false


### PR DESCRIPTION
## Summary

- Upgrade codecov-action v4 → v5 with OIDC tokenless authentication
- Add `permissions: id-token: write` for OIDC support
- Add `codecov.yml` config (target 80%, ignore examples)
- Matches goffi's Codecov setup for consistency across go-webgpu org