### PR TITLE
deps: update goffi v0.4.1 → v0.4.2, x/sys v0.40.0 → v0.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] - 2026-03-04
+
+### Changed
+
+- Update goffi v0.4.1 → v0.4.2 — purego compatibility fix (`nofakecgo` build tag for `_cgo_init` linker collision)
+- Update golang.org/x/sys v0.40.0 → v0.41.0
+
+---
+
 ## [0.4.1] - 2026-03-02
 
 ### Changed

--- a/UPSTREAM.md
+++ b/UPSTREAM.md
@@ -10,13 +10,14 @@ This document tracks upstream dependencies, pinned versions, and compatibility f
 |------------|---------|--------|------|
 | **wgpu-native** | [v27.0.4.0](https://github.com/gfx-rs/wgpu-native/releases/tag/v27.0.4.0) | [`768f15f`](https://github.com/gfx-rs/wgpu-native/commit/768f15f6ace8e4ec8e8720d5732b29e0b34250a8) | 2025-12-23 |
 | **webgpu.h** | wgpu-native bundled | same as above | — |
-| **goffi** | [v0.4.1](https://github.com/go-webgpu/goffi/releases/tag/v0.4.1) | [`7e87b11`](https://github.com/go-webgpu/goffi/commit/7e87b11) | 2026-03-02 |
+| **goffi** | [v0.4.2](https://github.com/go-webgpu/goffi/releases/tag/v0.4.2) | [`c8ef100`](https://github.com/go-webgpu/goffi/commit/c8ef100) | 2026-03-04 |
 | **gputypes** | [v0.2.0](https://github.com/gogpu/gputypes/releases/tag/v0.2.0) | [`146b8b2`](https://github.com/gogpu/gputypes/commit/146b8b253ad16fe23db83cc593601081d009e3a6) | 2026-01-29 |
 
 ## Compatibility Matrix
 
 | go-webgpu | wgpu-native | goffi | gputypes | Go |
 |-----------|-------------|-------|----------|----|
+| v0.4.2 | v27.0.4.0 | v0.4.2 | v0.2.0 | 1.25+ |
 | v0.4.1 | v27.0.4.0 | v0.4.1 | v0.2.0 | 1.25+ |
 | v0.4.0 | v27.0.4.0 | v0.4.0 | v0.2.0 | 1.25+ |
 | v0.3.2 | v27.0.4.0 | v0.4.0 | v0.2.0 | 1.25+ |
@@ -108,4 +109,4 @@ Enum values in gputypes follow the webgpu.h specification. When gputypes updates
 
 ---
 
-*Last updated: 2026-03-02 (v0.4.1)*
+*Last updated: 2026-03-04 (v0.4.2)*

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,8 @@ module github.com/go-webgpu/webgpu
 
 go 1.25
 
-require github.com/go-webgpu/goffi v0.4.1
+require github.com/go-webgpu/goffi v0.4.2
 
-require golang.org/x/sys v0.40.0
+require golang.org/x/sys v0.41.0
 
 require github.com/gogpu/gputypes v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
-github.com/go-webgpu/goffi v0.4.1 h1:2hQH5XXloxTyTtIleYv+Rajlwzp6UOETURhSZ5+zJxU=
-github.com/go-webgpu/goffi v0.4.1/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
+github.com/go-webgpu/goffi v0.4.2 h1:cwSiwro2ndP7jfXYlsz3kbOk8mNaFsHGZ0Q0cszC9cU=
+github.com/go-webgpu/goffi v0.4.2/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/gogpu/gputypes v0.2.0 h1:Quv3ekiU12zK4ZhBZsSZmalHYc+zj2gr9ZWRyzKgkKk=
 github.com/gogpu/gputypes v0.2.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
-golang.org/x/sys v0.40.0 h1:DBZZqJ2Rkml6QMQsZywtnjnnGvHza6BTfYFWY9kjEWQ=
-golang.org/x/sys v0.40.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
+golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=


### PR DESCRIPTION
## Changes

- **goffi** v0.4.1 → v0.4.2 — purego compatibility fix (`nofakecgo` build tag for `_cgo_init` linker collision)
- **golang.org/x/sys** v0.40.0 → v0.41.0

## Test plan

- [x] `go build ./...` passes
- [x] Safe tests pass (no GPU required)