### PR TITLE
deps: update goffi v0.4.2 → v0.5.0, gputypes v0.2.0 → v0.3.0, x/sys v0.41.0 → v0.42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3] - 2026-03-29
+
+### Changed
+
+- Update goffi v0.4.2 → v0.5.0 — Windows ARM64 (Snapdragon X) and FreeBSD amd64 support
+- Update gputypes v0.2.0 → v0.3.0 — `TextureUsage.ContainsUnknownBits()` method
+- Update golang.org/x/sys v0.41.0 → v0.42.0
+
+---
+
 ## [0.4.2] - 2026-03-04
 
 ### Changed

--- a/UPSTREAM.md
+++ b/UPSTREAM.md
@@ -10,13 +10,14 @@ This document tracks upstream dependencies, pinned versions, and compatibility f
 |------------|---------|--------|------|
 | **wgpu-native** | [v27.0.4.0](https://github.com/gfx-rs/wgpu-native/releases/tag/v27.0.4.0) | [`768f15f`](https://github.com/gfx-rs/wgpu-native/commit/768f15f6ace8e4ec8e8720d5732b29e0b34250a8) | 2025-12-23 |
 | **webgpu.h** | wgpu-native bundled | same as above | — |
-| **goffi** | [v0.4.2](https://github.com/go-webgpu/goffi/releases/tag/v0.4.2) | [`c8ef100`](https://github.com/go-webgpu/goffi/commit/c8ef100) | 2026-03-04 |
-| **gputypes** | [v0.2.0](https://github.com/gogpu/gputypes/releases/tag/v0.2.0) | [`146b8b2`](https://github.com/gogpu/gputypes/commit/146b8b253ad16fe23db83cc593601081d009e3a6) | 2026-01-29 |
+| **goffi** | [v0.5.0](https://github.com/go-webgpu/goffi/releases/tag/v0.5.0) | [`ca3231c`](https://github.com/go-webgpu/goffi/commit/ca3231c) | 2026-03-20 |
+| **gputypes** | [v0.3.0](https://github.com/gogpu/gputypes/releases/tag/v0.3.0) | [`209398e`](https://github.com/gogpu/gputypes/commit/209398e) | 2026-03-20 |
 
 ## Compatibility Matrix
 
 | go-webgpu | wgpu-native | goffi | gputypes | Go |
 |-----------|-------------|-------|----------|----|
+| v0.4.3 | v27.0.4.0 | v0.5.0 | v0.3.0 | 1.25+ |
 | v0.4.2 | v27.0.4.0 | v0.4.2 | v0.2.0 | 1.25+ |
 | v0.4.1 | v27.0.4.0 | v0.4.1 | v0.2.0 | 1.25+ |
 | v0.4.0 | v27.0.4.0 | v0.4.0 | v0.2.0 | 1.25+ |
@@ -109,4 +110,4 @@ Enum values in gputypes follow the webgpu.h specification. When gputypes updates
 
 ---
 
-*Last updated: 2026-03-04 (v0.4.2)*
+*Last updated: 2026-03-29 (v0.4.3)*

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/go-webgpu/webgpu
 
-go 1.25
+go 1.25.0
 
-require github.com/go-webgpu/goffi v0.4.2
+require github.com/go-webgpu/goffi v0.5.0
 
-require golang.org/x/sys v0.41.0
+require golang.org/x/sys v0.42.0
 
-require github.com/gogpu/gputypes v0.2.0
+require github.com/gogpu/gputypes v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
-github.com/go-webgpu/goffi v0.4.2 h1:cwSiwro2ndP7jfXYlsz3kbOk8mNaFsHGZ0Q0cszC9cU=
-github.com/go-webgpu/goffi v0.4.2/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
-github.com/gogpu/gputypes v0.2.0 h1:Quv3ekiU12zK4ZhBZsSZmalHYc+zj2gr9ZWRyzKgkKk=
-github.com/gogpu/gputypes v0.2.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
-golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
-golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE=
+github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
+github.com/gogpu/gputypes v0.3.0 h1:gcwxsBrcoCX19GqqqiV55wLv2iFwaybiOluKCb0hVrs=
+github.com/gogpu/gputypes v0.3.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
+golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
+golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=


### PR DESCRIPTION
## Changes

- **goffi** v0.4.2 → v0.5.0 — Windows ARM64 (Snapdragon X) and FreeBSD amd64 support
- **gputypes** v0.2.0 → v0.3.0 — `TextureUsage.ContainsUnknownBits()` method
- **golang.org/x/sys** v0.41.0 → v0.42.0

## Test plan

- [x] `go build ./...` passes
- [x] Safe tests pass (no GPU required)