### PR TITLE
feat(wgpu): add Android native-window surface source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Android `ANativeWindow*` surface creation through
+  `Instance.CreateSurfaceFromAndroidNativeWindow`, including v29 wire-layout
+  and zero-handle validation tests.
+
 ## v0.5.3 (2026-07-12)
 
 ### Changed

--- a/wgpu/surface_android.go
+++ b/wgpu/surface_android.go
@@ -1,0 +1,42 @@
+//go:build android
+
+package wgpu
+
+import (
+	"runtime"
+	"unsafe"
+)
+
+// CreateSurfaceFromAndroidNativeWindow creates a surface from an
+// ANativeWindow. The caller must keep its ANativeWindow reference alive until
+// the returned Surface is released.
+func (inst *Instance) CreateSurfaceFromAndroidNativeWindow(window uintptr) (*Surface, error) {
+	if err := checkInit(); err != nil {
+		return nil, err
+	}
+	if inst == nil || inst.handle == 0 {
+		return nil, &WGPUError{Op: "CreateSurface", Message: "instance is nil or released"}
+	}
+
+	source, err := newSurfaceSourceAndroidNativeWindow(window)
+	if err != nil {
+		return nil, err
+	}
+	desc := surfaceDescriptor{
+		nextInChain: uintptr(unsafe.Pointer(&source)),
+		label:       EmptyStringView(),
+	}
+
+	handle, _, _ := procInstanceCreateSurface.Call(
+		inst.handle,
+		uintptr(unsafe.Pointer(&desc)),
+	)
+	runtime.KeepAlive(&source)
+	runtime.KeepAlive(&desc)
+	if handle == 0 {
+		return nil, &WGPUError{Op: "CreateSurface", Message: "failed to create surface"}
+	}
+
+	trackResource(handle, "Surface")
+	return &Surface{handle: handle}, nil
+}

--- a/wgpu/surface_android.go
+++ b/wgpu/surface_android.go
@@ -3,7 +3,6 @@
 package wgpu
 
 import (
-	"runtime"
 	"unsafe"
 )
 
@@ -31,8 +30,6 @@ func (inst *Instance) CreateSurfaceFromAndroidNativeWindow(window uintptr) (*Sur
 		inst.handle,
 		uintptr(unsafe.Pointer(&desc)),
 	)
-	runtime.KeepAlive(&source)
-	runtime.KeepAlive(&desc)
 	if handle == 0 {
 		return nil, &WGPUError{Op: "CreateSurface", Message: "failed to create surface"}
 	}

--- a/wgpu/surface_android_test.go
+++ b/wgpu/surface_android_test.go
@@ -1,0 +1,5 @@
+//go:build android
+
+package wgpu
+
+var _ func(*Instance, uintptr) (*Surface, error) = (*Instance).CreateSurfaceFromAndroidNativeWindow

--- a/wgpu/surface_android_wire.go
+++ b/wgpu/surface_android_wire.go
@@ -4,8 +4,8 @@ package wgpu
 // WGPUSurfaceSourceAndroidNativeWindow in the WebGPU native v29 header.
 // It is host-buildable so ordinary CI can verify the Android ABI layout.
 type surfaceSourceAndroidNativeWindow struct {
-	chain  ChainedStruct
-	window uintptr // ANativeWindow*
+	chain  ChainedStruct // 16 bytes: next (8) + sType (4) + padding (4)
+	window uintptr       // 8 bytes - ANativeWindow*
 }
 
 func newSurfaceSourceAndroidNativeWindow(window uintptr) (surfaceSourceAndroidNativeWindow, error) {
@@ -18,6 +18,7 @@ func newSurfaceSourceAndroidNativeWindow(window uintptr) (surfaceSourceAndroidNa
 
 	return surfaceSourceAndroidNativeWindow{
 		chain: ChainedStruct{
+			Next:  0,
 			SType: uint32(STypeSurfaceSourceAndroidNativeWindow),
 		},
 		window: window,

--- a/wgpu/surface_android_wire.go
+++ b/wgpu/surface_android_wire.go
@@ -1,0 +1,25 @@
+package wgpu
+
+// surfaceSourceAndroidNativeWindow matches
+// WGPUSurfaceSourceAndroidNativeWindow in the WebGPU native v29 header.
+// It is host-buildable so ordinary CI can verify the Android ABI layout.
+type surfaceSourceAndroidNativeWindow struct {
+	chain  ChainedStruct
+	window uintptr // ANativeWindow*
+}
+
+func newSurfaceSourceAndroidNativeWindow(window uintptr) (surfaceSourceAndroidNativeWindow, error) {
+	if window == 0 {
+		return surfaceSourceAndroidNativeWindow{}, &WGPUError{
+			Op:      "CreateSurface",
+			Message: "Android native window is nil",
+		}
+	}
+
+	return surfaceSourceAndroidNativeWindow{
+		chain: ChainedStruct{
+			SType: uint32(STypeSurfaceSourceAndroidNativeWindow),
+		},
+		window: window,
+	}, nil
+}

--- a/wgpu/surface_android_wire_test.go
+++ b/wgpu/surface_android_wire_test.go
@@ -1,0 +1,36 @@
+package wgpu
+
+import (
+	"testing"
+	"unsafe"
+)
+
+func TestABISurfaceSourceAndroidNativeWindow(t *testing.T) {
+	source, err := newSurfaceSourceAndroidNativeWindow(0x1234)
+	if err != nil {
+		t.Fatalf("newSurfaceSourceAndroidNativeWindow: %v", err)
+	}
+
+	if got := unsafe.Sizeof(source); got != 24 {
+		t.Fatalf("sizeof(surfaceSourceAndroidNativeWindow) = %d, want 24", got)
+	}
+	if got := unsafe.Offsetof(source.window); got != 16 {
+		t.Fatalf("offsetof(window) = %d, want 16", got)
+	}
+	if source.chain.Next != 0 {
+		t.Fatalf("chain.Next = %#x, want 0", source.chain.Next)
+	}
+	if source.chain.SType != uint32(STypeSurfaceSourceAndroidNativeWindow) {
+		t.Fatalf("chain.SType = %#x, want %#x", source.chain.SType, uint32(STypeSurfaceSourceAndroidNativeWindow))
+	}
+	if source.window != 0x1234 {
+		t.Fatalf("window = %#x, want 0x1234", source.window)
+	}
+}
+
+func TestSurfaceSourceAndroidNativeWindowRejectsZero(t *testing.T) {
+	_, err := newSurfaceSourceAndroidNativeWindow(0)
+	if err == nil {
+		t.Fatal("newSurfaceSourceAndroidNativeWindow(0) succeeded")
+	}
+}


### PR DESCRIPTION
## Summary

Add the missing wgpu-native v29 Android surface-source wrapper:

- expose `Instance.CreateSurfaceFromAndroidNativeWindow` on Android;
- build `WGPUSurfaceSourceAndroidNativeWindow` with the existing v29 `SType`;
- reject a zero `ANativeWindow*` before FFI;
- keep the wire descriptor alive for the native call; and
- verify the AArch64 wire size, field offset, chain tag, and Android method surface.

## Why

The bindings already expose `STypeSurfaceSourceAndroidNativeWindow`, but there is no constructor that can pass the corresponding chained descriptor to `wgpuInstanceCreateSurface`. That leaves Android consumers unable to use wgpu-native through the canonical Go wrapper.

This is the Rust-wrapper prerequisite for [gogpu/wgpu#273](https://github.com/gogpu/wgpu/pull/273). The #273 description records its current exact integration head; its CI pins this PR at exact helper head `08592c9f5916b64dfc70aba9e67a74a764bb3ef5` through the canonical PR ref. After #24 merges and is released, #273 can consume the canonical version. The pure-Go Vulkan implementation in [gogpu/wgpu#268](https://github.com/gogpu/wgpu/pull/268) does not depend on this helper; only the optional `-tags rust` Android path does.

## Ownership boundary

The caller owns its `ANativeWindow` reference and must keep it valid until the returned surface is released. This method neither acquires nor releases the window, and it adds no Activity, JNI, packaging, cgo, or nativeexport policy.

Android API 29 is a downstream install/native floor and API 36 is a downstream application compile/target choice; the wgpu-native wire descriptor itself is API-level independent.

## Validation

- `GOWORK=off go test ./wgpu -run 'Test(ABISurfaceSourceAndroidNativeWindow|SurfaceSourceAndroidNativeWindowRejectsZero)$'`
- `GOOS=android GOARCH=arm64 CGO_ENABLED=0 GOWORK=off go test -exec=true ./wgpu`
- `git diff --check`

The full downstream WGPU Android matrix on the current #273 branch compiles every package and test through this exact helper head in both cgo modes and audits the resulting Rust-wrapper ELF dependency on `libwgpu_native.so`.
