### PR TITLE
release: v0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## v0.5.4 (2026-07-24)
 
 ### Added
 
 - Android `ANativeWindow*` surface creation through
   `Instance.CreateSurfaceFromAndroidNativeWindow`, including v29 wire-layout
-  and zero-handle validation tests.
+  and zero-handle validation tests ([#24](https://github.com/go-webgpu/webgpu/pull/24) by [@besmpl](https://github.com/besmpl))
+- `Queue.GetTimestampPeriod()` — returns GPU timestamp tick duration in nanoseconds via platform-correct float32 ABI path ([#23](https://github.com/go-webgpu/webgpu/pull/23) by [@besmpl](https://github.com/besmpl))
+- `float32Proc` interface and shared `callFloat32` path for procedures with native float returns
+
+### Fixed
+
+- **macOS/Linux: RequestAdapter no longer hangs** — callback entry points now correctly reconstruct `WGPUStringView` from two integer registers on Unix amd64/arm64 and Windows ARM64, preserving `userdata` for request completion. Windows x64 retains its indirect-aggregate convention. Closes [#17](https://github.com/go-webgpu/webgpu/issues/17) ([#25](https://github.com/go-webgpu/webgpu/pull/25) by [@besmpl](https://github.com/besmpl))
+- `go vet` warning in `loader_windows.go` — use `ptrFromUintptr` for DLL function address conversion
+- Consolidate three separate `require` directives in `go.mod` into a single block
+
+### Changed
+
+- **deps:** goffi v0.6.0 → v0.6.2 — Windows x64 float return via XMM0 capture, Android ARM64 preview
 
 ## v0.5.3 (2026-07-12)
 

--- a/UPSTREAM.md
+++ b/UPSTREAM.md
@@ -10,13 +10,14 @@ This document tracks upstream dependencies, pinned versions, and compatibility f
 |------------|---------|--------|------|
 | **wgpu-native** | [v29.0.0.0](https://github.com/gfx-rs/wgpu-native/releases/tag/v29.0.0.0) | — | 2026-04-10 |
 | **webgpu.h** | wgpu-native bundled | [`7d3186c`](https://github.com/webgpu-native/webgpu-headers/commit/7d3186c3dd2c708703524027b46b8703534ab3cc) | stable |
-| **goffi** | [v0.6.0](https://github.com/go-webgpu/goffi/releases/tag/v0.6.0) | [`895a3fa`](https://github.com/go-webgpu/goffi/commit/895a3fa) | 2026-07-12 |
+| **goffi** | [v0.6.2](https://github.com/go-webgpu/goffi/releases/tag/v0.6.2) | [`895a3fa`](https://github.com/go-webgpu/goffi/commit/895a3fa) | 2026-07-22 |
 | **gputypes** | [v0.5.1](https://github.com/gogpu/gputypes/releases/tag/v0.5.1) | [`239da90`](https://github.com/gogpu/gputypes/commit/239da90) | 2026-07-12 |
 
 ## Compatibility Matrix
 
 | go-webgpu | wgpu-native | goffi | gputypes | Go |
 |-----------|-------------|-------|----------|----|
+| v0.5.4 | v29.0.0.0 | v0.6.2 | v0.5.1 | 1.25+ |
 | v0.5.3 | v29.0.0.0 | v0.6.0 | v0.5.1 | 1.25+ |
 | v0.5.0 | v29.0.0.0 | v0.5.0 | v0.3.0 | 1.25+ |
 | v0.4.3 | v27.0.4.0 | v0.5.0 | v0.3.0 | 1.25+ |

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,8 @@ module github.com/go-webgpu/webgpu
 
 go 1.25.0
 
-require github.com/go-webgpu/goffi v0.6.2
-
-require golang.org/x/sys v0.47.0
-
-require github.com/gogpu/gputypes v0.5.1
+require (
+	github.com/go-webgpu/goffi v0.6.2
+	github.com/gogpu/gputypes v0.5.1
+	golang.org/x/sys v0.47.0
+)

--- a/wgpu/loader_windows.go
+++ b/wgpu/loader_windows.go
@@ -4,7 +4,6 @@ package wgpu
 
 import (
 	"syscall"
-	"unsafe"
 
 	"github.com/go-webgpu/goffi/types"
 )
@@ -55,7 +54,7 @@ func (w *windowsProc) CallFloat32(args ...uintptr) (float32, error) {
 		nativeFloat32CallOps,
 		w.proc.Name,
 		types.WindowsCallingConvention,
-		unsafe.Pointer(w.proc.Addr()),
+		ptrFromUintptr(w.proc.Addr()),
 		args...,
 	)
 }


### PR DESCRIPTION
## v0.5.4

### Added

- Android `ANativeWindow*` surface creation through `Instance.CreateSurfaceFromAndroidNativeWindow` (#24 by @besmpl)
- `Queue.GetTimestampPeriod()` — GPU timestamp tick duration via platform-correct float32 ABI path (#23 by @besmpl)
- `float32Proc` interface and shared `callFloat32` path for native float returns

### Fixed

- **macOS/Linux: RequestAdapter no longer hangs** — callback entry points now correctly reconstruct `WGPUStringView` from two integer registers on Unix amd64/arm64 and Windows ARM64. Closes #17 (#25 by @besmpl)
- `go vet` warning in `loader_windows.go` — use `ptrFromUintptr` for DLL function address conversion
- Consolidate `go.mod` require directives into a single block

### Changed

- **deps:** goffi v0.6.0 → v0.6.2 — Windows x64 float return via XMM0 capture, Android ARM64 preview